### PR TITLE
Aqua品質検査を有効化する

### DIFF
--- a/src/phaseDiagram.jl
+++ b/src/phaseDiagram.jl
@@ -126,7 +126,7 @@ function update2D!(
 end
 
 # Old method
-function update1D!(nums, num0, H, alg!, range1, ::UseSingleThread, p::Params)
+function update1D!(nums::AbstractArray, num0, H, alg!, range1, ::UseSingleThread, p::Params)
     for i in eachindex(range1)
         update1Din!(i, nums, num0, H, alg!, range1, p)
     end
@@ -134,7 +134,14 @@ end
 
 # Old method
 function update1D!(
-    nums, num0, H, alg!, range1, idxs::ProgressBar, ::UseSingleThread, p::Params
+    nums::AbstractArray,
+    num0,
+    H,
+    alg!,
+    range1,
+    idxs::ProgressBar,
+    ::UseSingleThread,
+    p::Params,
 )
     for i in idxs
         update1Din!(i, nums, num0, H, alg!, range1, p)
@@ -142,7 +149,9 @@ function update1D!(
 end
 
 # Old method
-function update2D!(nums, num0, H, alg!, range1, range2, ::UseSingleThread, p::Params)
+function update2D!(
+    nums::AbstractArray, num0, H, alg!, range1, range2, ::UseSingleThread, p::Params
+)
     for i in eachindex(range1), j in eachindex(range2)
         update2Din!(i, j, nums, num0, H, alg!, range1, range2, p)
     end
@@ -150,7 +159,15 @@ end
 
 # Old method
 function update2D!(
-    nums, num0, H, alg!, range1, range2, idxs::ProgressBar, ::UseSingleThread, p::Params
+    nums::AbstractArray,
+    num0,
+    H,
+    alg!,
+    range1,
+    range2,
+    idxs::ProgressBar,
+    ::UseSingleThread,
+    p::Params,
 )
     for i in idxs, j in eachindex(range2)
         update2Din!(i, j, nums, num0, H, alg!, range1, range2, p)
@@ -300,7 +317,7 @@ function update2D!(
 end
 
 # Old method
-function update1D!(nums, num0, H, alg!, range1, mod::UseMPI, p::Params)
+function update1D!(nums::AbstractArray, num0, H, alg!, range1, mod::UseMPI, p::Params)
     mod.MPI.Init()
     comm = mod.MPI.COMM_WORLD
     myrank = mod.MPI.Comm_rank(comm)
@@ -318,7 +335,9 @@ function update1D!(nums, num0, H, alg!, range1, mod::UseMPI, p::Params)
 end
 
 # Old method
-function update1D!(nums, num0, H, alg!, range1, idxs::ProgressBar, mod::UseMPI, p::Params)
+function update1D!(
+    nums::AbstractArray, num0, H, alg!, range1, idxs::ProgressBar, mod::UseMPI, p::Params
+)
     mod.MPI.Init()
     comm = mod.MPI.COMM_WORLD
     myrank = mod.MPI.Comm_rank(comm)
@@ -339,7 +358,9 @@ function update1D!(nums, num0, H, alg!, range1, idxs::ProgressBar, mod::UseMPI, 
 end
 
 # Old method
-function update2D!(nums, num0, H, alg!, range1, range2, mod::UseMPI, p::Params)
+function update2D!(
+    nums::AbstractArray, num0, H, alg!, range1, range2, mod::UseMPI, p::Params
+)
     mod.MPI.Init()
     comm = mod.MPI.COMM_WORLD
     myrank = mod.MPI.Comm_rank(comm)
@@ -360,7 +381,15 @@ end
 
 # Old method
 function update2D!(
-    nums, num0, H, alg!, range1, range2, idxs::ProgressBar, mod::UseMPI, p::Params
+    nums::AbstractArray,
+    num0,
+    H,
+    alg!,
+    range1,
+    range2,
+    idxs::ProgressBar,
+    mod::UseMPI,
+    p::Params,
 )
     mod.MPI.Init()
     comm = mod.MPI.COMM_WORLD

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -9,7 +9,7 @@ PythonPlot = "274fc56d-3b97-40fa-a1cd-1b4a50311bf9"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Aqua = "0.6"
+Aqua = "0.8"
 CondaPkg = "0.2"
 JuliaFormatter = "1.0"
 LinearAlgebra = "^1.6"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,8 +20,10 @@ const pf = pyimport("pfapack.pfaffian")
 # const cpf = pyimport("pfapack.ctypes").pfaffian
 const np = pyimport("numpy")
 
-# using Aqua
-# Aqua.test_all(TopologicalNumbers; ambiguities=false)
+using Aqua
+Aqua.test_all(TopologicalNumbers; ambiguities=false)
+# 依存パッケージ同士を除外し、本パッケージが定義したメソッドの曖昧性を検査する。
+Aqua.test_ambiguities(TopologicalNumbers)
 
 @testset "TopologicalNumbers.jl" begin
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,9 +21,11 @@ const pf = pyimport("pfapack.pfaffian")
 const np = pyimport("numpy")
 
 using Aqua
-Aqua.test_all(TopologicalNumbers; ambiguities=false)
-# 依存パッケージ同士を除外し、本パッケージが定義したメソッドの曖昧性を検査する。
-Aqua.test_ambiguities(TopologicalNumbers)
+@testset "Aqua品質検査" begin
+    Aqua.test_all(TopologicalNumbers; ambiguities=false)
+    # 依存パッケージ同士を除外し、本パッケージが定義したメソッドの曖昧性を検査する。
+    Aqua.test_ambiguities(TopologicalNumbers)
+end
 
 @testset "TopologicalNumbers.jl" begin
 


### PR DESCRIPTION
## 概要

Aquaを現行版へ更新し、型パラメータ、依存、互換性、persistent taskなどの品質検査をテストへ組み込みます。

## 検証

全変更を集約した統合監査で、Julia 1.12.6は293/293、Julia 1.6.7は全テスト、性能ゲートは6/6、Documenterビルドは成功しています。

## 依存・マージ順

- #88 を先にマージしてください。PythonPlot 1.0.7は単独プリコンパイル時に同名メソッドを上書きするため、Aquaのpersistent-task検査を正しく完走させるにはPythonPlotの遅延読込が必要です。
- #83 の後を推奨します。