### PR TITLE
JuliaとOSのCIマトリクスを拡張する

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,70 +10,64 @@ concurrency:
   # Cancel intermediate builds: only if it is a pull request build.
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+env:
+  MPLBACKEND: Agg
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    permissions:
+      actions: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
         version:
-          # - "1.6"
-          # - "1.9"
+          - "1.6"
           - "1.10"
           - "1.11"
-          # - "nightly"
+          - "1"
         os:
           - ubuntu-latest
-          # - macOS-latest
-          # - windows-latest
+          - windows-latest
         arch:
           - x64
+        exclude:
+          - version: "1.6"
+            os: windows-latest
+          - version: "1.10"
+            os: windows-latest
+          - version: "1.11"
+            os: windows-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
-      # - run: sudo apt-get update -y && sudo apt-get upgrade -y && sudo apt-get install -y cmake xorg-dev mesa-utils xvfb libgl1 freeglut3-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev libgl1-mesa-glx
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-        # with:
-        #   prefix: xvfb-run
-        # env:
-        #   LD_PRELOAD: /usr/lib/x86_64-linux-gnu/libstdc++.so.6
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
+      - uses: codecov/codecov-action@v5
+        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
         with:
           files: lcov.info
   docs:
     name: Documentation
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       statuses: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "1"
-      # - run: sudo apt-get update && sudo apt-get install -y xorg-dev mesa-utils xvfb libgl1 freeglut3-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev
-      # - name: Configure doc environment
-      #   run: |
-      #     julia --project=docs/ -e '
-      #       using Pkg
-      #       Pkg.develop(PackageSpec(path=pwd()))
-      #       Pkg.instantiate()'
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1
-        # with:
-        #   prefix: xvfb-run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # - run: |
-      #     julia --project=docs -e '
-      #       using Documenter: DocMeta, doctest
-      #       using TopologicalNumbers
-      #       DocMeta.setdocmeta!(TopologicalNumbers, :DocTestSetup, :(using TopologicalNumbers); recursive=true)
-      #       doctest(TopologicalNumbers)'

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ The correspondence between the spatial dimension of the system and the supported
 
 
 This software is released under the MIT License, please see the LICENSE file for more details.  
-It is confirmed to work on Julia 1.10 (LTS) and 1.11.
+The package supports Julia 1.6 or later. CI tests Julia 1.6, 1.10, 1.11, and the
+latest stable Julia release.
 
 
 ## Installation

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -45,7 +45,8 @@ the Shiozaki method [Fukui2007Quantum,Shiozaki2023discrete](@cite),
 or method of calculating the Weyl nodes [Hirayama2018Topological,Yang2011Quantum,Hirayama2015Weyl,Du2017Emergence](@cite).
 
 This software is released under the MIT License, please see the LICENSE file for more details.  
-It is confirmed to work on Julia 1.10 (LTS) and 1.11.
+The package supports Julia 1.6 or later. CI tests Julia 1.6, 1.10, 1.11, and the
+latest stable Julia release.
 
 
 ## Installation


### PR DESCRIPTION
## 概要

Julia 1.6、1.10、1.11、最新、およびWindowsを検証対象に追加し、対応版の文書を揃えます。

## 検証

全変更を集約した統合監査で、Julia 1.12.6は293/293、Julia 1.6.7は全テスト、性能ゲートは6/6、Documenterビルドは成功しています。

## 依存・マージ順

codex/add-performance-gate と codex/lazy-load-pythonplot の後を推奨します。