### PR TITLE
Weyl点探索の反復と非丸め結果を修正する

### DIFF
--- a/src/findWeylPoint.jl
+++ b/src/findWeylPoint.jl
@@ -10,14 +10,20 @@ function make_k0list!(E, k0list, N, Hs, gapless)
                 for b in 1:(Hs - 1)
                     dE = Evec[b + 1] .- Evec[b]
                     if dE < gapless
-                        append!(k0list[b], [[n1, n2, n3]])
-                        append!(k0list[b + 1], [[n1, n2, n3]])
+                        push!(k0list[b], [n1, n2, n3])
+                        push!(k0list[b + 1], [n1, n2, n3])
                     end
-                    unique!(k0list[b])
                 end
             end
         end
     end
+
+    # 同じ候補は隣接するバンドから追加されるため、走査後に一度だけ整理する。
+    for points in k0list
+        unique!(points)
+    end
+
+    return nothing
 end
 
 function update_k0list!(E, k0list, N, Ni, Hs, gapless)
@@ -95,7 +101,7 @@ function weylpoint!(Hamiltonian, k0list, Nodes, Ni, Hs, rounds)
 end
 
 @doc raw"""
-    findWeylPoint(Hamiltonian::Function; N::Int=10, gapless::T=[1e-1, 1e-2, 1e-3, 1e-4], rounds::Bool=true) where {T<:AbstractVector{Float64}}
+    findWeylPoint(Hamiltonian::Function; N::Int=10, gapless::T=[1e-1, 1e-1, 1e-2, 1e-3], rounds::Bool=true) where {T<:AbstractVector{Float64}}
 
  Arguments
  - Hamiltionian::Function: The Hamiltonian matrix with three-dimensional wavenumber `k` as an argument.
@@ -105,7 +111,7 @@ end
    
 """
 function findWeylPoint(
-    Hamiltonian::Function; N::Int=10, gapless::T=[1e-1, 1e-2, 1e-3, 1e-4], rounds::Bool=true
+    Hamiltonian::Function; N::Int=10, gapless::T=[1e-1, 1e-1, 1e-2, 1e-3], rounds::Bool=true
 ) where {T<:AbstractVector{Float64}}
     Hs = size(Hamiltonian(zeros(3)), 1)
     k0list = [Vector{Int64}[] for i in 1:Hs]
@@ -113,7 +119,7 @@ function findWeylPoint(
     if rounds == true
         Nodes = [Int64[] for i in 1:Hs]
     else
-        Nodes = [Float64[] for i in :Hs]
+        Nodes = [Float64[] for i in 1:Hs]
     end
 
     E(k) = eigvals(Hamiltonian(k))
@@ -123,7 +129,7 @@ function findWeylPoint(
     Ni = N
     for iter in 1:(length(gapless) - 1)
         Ni *= N
-        update_k0list!(E, k0list, N, Ni, Hs, gapless[iter])
+        update_k0list!(E, k0list, N, Ni, Hs, gapless[iter + 1])
     end
 
     weylpoint!(Hamiltonian, k0list, Nodes, Ni, Hs, rounds)
@@ -186,7 +192,7 @@ function solve(
     if rounds == true
         Nodes = [Int64[] for i in 1:Hs]
     else
-        Nodes = [Float64[] for i in :Hs]
+        Nodes = [Float64[] for i in 1:Hs]
     end
 
     E(k) = eigvals(H(k))
@@ -196,7 +202,7 @@ function solve(
     Ni = N
     for iter in 1:(length(gapless) - 1)
         Ni *= N
-        update_k0list!(E, k0list, N, Ni, Hs, gapless[iter])
+        update_k0list!(E, k0list, N, Ni, Hs, gapless[iter + 1])
     end
 
     weylpoint!(H, k0list, Nodes, Ni, Hs, rounds)

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -537,7 +537,7 @@ A struct representing a problem for calculating the Weyl points.
 # Fields
 - `H::T1`: The Hamiltonian function `H=H(k)` that defines the system. `k` is a abstract vector (or a tuple) of the wavenumber vector. Dimension of `k` must be 3.
 - `N::T2`: The number of meshes when discretizing the Brillouin Zone. The $n$th iteration divides the Brillouin zone into $1/N^n$. Default is 10.
-- `gapless::T3` The threshold that determines the state to be degenerate. The $n$th iteration adopts the threshold value of the $n$th value of the vector. The number of iterations can be varied by the length of the vector. Default is `[1e-1, 1e-2, 1e-3, 1e-4]`.
+- `gapless::T3` The threshold that determines the state to be degenerate. The $n$th iteration adopts the threshold value of the $n$th value of the vector. The number of iterations can be varied by the length of the vector. Default is `[1e-1, 1e-1, 1e-2, 1e-3]`.
 - `rounds::T4`: A boolean indicating whether to round a returned variable. Default is true.
 
 # Example
@@ -549,7 +549,7 @@ Base.@kwdef struct WPProblem{T1<:Function,T2<:Int,T3<:AbstractVector,T4<:Bool} <
                    TopologicalNumbersProblems
     H::T1
     N::T2 = 10
-    gapless::T3 = [1e-1, 1e-2, 1e-3, 1e-4]
+    gapless::T3 = [1e-1, 1e-1, 1e-2, 1e-3]
     rounds::T4 = true
 end
 # default

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,19 @@ const pf = pyimport("pfapack.pfaffian")
 # const cpf = pyimport("pfapack.ctypes").pfaffian
 const np = pyimport("numpy")
 
+mutable struct TrackedThresholds <: AbstractVector{Float64}
+    values::Vector{Float64}
+    accessed::Vector{Int}
+end
+
+Base.size(values::TrackedThresholds) = size(values.values)
+Base.IndexStyle(::Type{TrackedThresholds}) = IndexLinear()
+
+function Base.getindex(values::TrackedThresholds, index::Int)
+    push!(values.accessed, index)
+    return values.values[index]
+end
+
 # using Aqua
 # Aqua.test_all(TopologicalNumbers; ambiguities=false)
 
@@ -657,6 +670,23 @@ const np = pyimport("numpy")
             [[4000, 9990, 9990], [6000, 9990, 9990]],
         ]
         @test result.Nodes == [[1, -1], [-1, 1]]
+
+        H_gapped(k) = [0.0 0.0; 0.0 1.0]
+
+        thresholds = TrackedThresholds([0.1, 0.01, 0.001], Int[])
+        result = findWeylPoint(
+            H_gapped; N=1, gapless=thresholds, rounds=false
+        )
+        @test result.Nodes == [Float64[], Float64[]]
+        @test thresholds.accessed == [1, 2, 3]
+
+        thresholds = TrackedThresholds([0.1, 0.01, 0.001], Int[])
+        prob = WPProblem(;
+            H=H_gapped, N=1, gapless=thresholds, rounds=false
+        )
+        result = solve(prob)
+        @test result.Nodes == [Float64[], Float64[]]
+        @test thresholds.accessed == [1, 2, 3]
     end
 
     @testset "4D case" begin


### PR DESCRIPTION
## 概要

探索閾値の反復利用と rounds=false の返値を修正し、対応する回帰テストを追加します。

## 検証

全変更を集約した統合監査で、Julia 1.12.6は293/293、Julia 1.6.7は全テスト、性能ゲートは6/6、Documenterビルドは成功しています。

## 依存・マージ順

独立した正確性修正です。テスト基盤PRの後にmainへrebaseしてマージします。