### PR TITLE
第二Chern数の異方メッシュを修正する

### DIFF
--- a/src/SecondChern.jl
+++ b/src/SecondChern.jl
@@ -176,51 +176,30 @@ function setParams(p)
     return (; r, sys) # Return parameters
 end
 
-# Function to fix the gauge at the boundaries
+# 各軸の終端を始点と同じ基底にそろえ、周期境界でゲージを固定する。
 function boundaryGauge(r, s::TemporalSecondChern)
-    for i in eachindex(r.Kxrange), j in eachindex(r.Kyrange), l in eachindex(r.Kzrange)
-        s.evec[l, j, i, r.Nz + 1] = s.evec[l, j, i, 1]
-    end
-    for i in eachindex(r.Kxrange), j in eachindex(r.Kyrange), l in eachindex(r.Kzrange)
-        s.evec[l, j, r.Nz + 1, i] = s.evec[l, j, 1, i]
-    end
-    for i in eachindex(r.Kxrange), j in eachindex(r.Kyrange), l in eachindex(r.Kzrange)
-        s.evec[l, r.Ny + 1, j, i] = s.evec[l, 1, j, i]
-    end
-    for i in eachindex(r.Kxrange), j in eachindex(r.Kyrange), l in eachindex(r.Kzrange)
-        s.evec[r.Nz + 1, l, j, i] = s.evec[1, l, j, i]
+    for j in eachindex(r.Kyrange),
+        l in eachindex(r.Kzrange),
+        m in eachindex(r.Kwrange)
+        s.evec[r.Nx + 1, j, l, m] = s.evec[1, j, l, m]
     end
 
-    for i in eachindex(r.Kxrange), j in eachindex(r.Kyrange)
-        s.evec[j, i, r.Nz + 1, r.Nw + 1] = s.evec[j, i, 1, 1]
-    end
-    for i in eachindex(r.Kxrange), j in eachindex(r.Kyrange)
-        s.evec[j, r.Nz + 1, i, r.Nw + 1] = s.evec[j, 1, i, 1]
-    end
-    for i in eachindex(r.Kxrange), j in eachindex(r.Kyrange)
-        s.evec[r.Ny + 1, j, i, r.Nw + 1] = s.evec[1, j, i, 1]
-    end
-    for i in eachindex(r.Kxrange), j in eachindex(r.Kyrange)
-        s.evec[j, r.Nz + 1, r.Nw + 1, i] = s.evec[j, 1, 1, i]
-    end
-    for i in eachindex(r.Kxrange), j in eachindex(r.Kyrange)
-        s.evec[r.Nz + 1, j, r.Nw + 1, i] = s.evec[1, j, 1, i]
-    end
-    for i in eachindex(r.Kxrange), j in eachindex(r.Kyrange)
-        s.evec[r.Ny + 1, r.Nz + 1, j, i] = s.evec[1, 1, j, i]
+    for i in eachindex(r.Kxrange),
+        l in eachindex(r.Kzrange),
+        m in eachindex(r.Kwrange)
+        s.evec[i, r.Ny + 1, l, m] = s.evec[i, 1, l, m]
     end
 
-    for i in eachindex(r.Kxrange)
-        s.evec[i, r.Ny + 1, r.Nz + 1, r.Nw + 1] = s.evec[i, 1, 1, 1]
+    for i in eachindex(r.Kxrange),
+        j in eachindex(r.Kyrange),
+        m in eachindex(r.Kwrange)
+        s.evec[i, j, r.Nz + 1, m] = s.evec[i, j, 1, m]
     end
-    for i in eachindex(r.Kxrange)
-        s.evec[r.Nz + 1, i, r.Ny + 1, r.Nw + 1] = s.evec[1, i, 1, 1]
-    end
-    for i in eachindex(r.Kxrange)
-        s.evec[r.Ny + 1, r.Nz + 1, i, r.Nw + 1] = s.evec[1, 1, i, 1]
-    end
-    for i in eachindex(r.Kxrange)
-        s.evec[r.Nz + 1, r.Ny + 1, r.Nw + 1, i] = s.evec[1, 1, 1, i]
+
+    for i in eachindex(r.Kxrange),
+        j in eachindex(r.Kyrange),
+        l in eachindex(r.Kzrange)
+        s.evec[i, j, l, r.Nw + 1] = s.evec[i, j, l, 1]
     end
 
     return s.evec[r.Nx + 1, r.Ny + 1, r.Nz + 1, r.Nw + 1] = s.evec[1, 1, 1, 1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -696,6 +696,11 @@ const np = pyimport("numpy")
                 @test calcSecondChern(H; N, parallel=UseMPI(MPI)).TopologicalNumber ≈
                     0.8309301430562057
 
+                anisotropic_prob = SCProblem(H, (2, 3, 2, 2))
+                @test solve(anisotropic_prob).TopologicalNumber ≈ 0.0 atol = 1e-10
+                @test calcSecondChern(H; N=(3, 4, 5, 6)).TopologicalNumber ≈
+                    0.20176270231048674 atol = 1e-8
+
                 SCProblem(H)
                 SCProblem(H, 1)
                 prob = SCProblem(; H, N)


### PR DESCRIPTION
## 概要

4方向で異なるメッシュ数を正しく利用し、異方格子の回帰値を検証します。

## 検証

全変更を集約した統合監査で、Julia 1.12.6は293/293、Julia 1.6.7は全テスト、性能ゲートは6/6、Documenterビルドは成功しています。

## 依存・マージ順

独立した正確性修正です。