### PR TITLE
第二Chern数の虚部警告経路を修正する

### DIFF
--- a/src/SecondChern.jl
+++ b/src/SecondChern.jl
@@ -287,7 +287,7 @@ end
 
 function warn_finiteImaginary(x)
     if abs(imag(x)) > 1e-10
-        warn("Imaginary part of the second Chern number has a finite value.")
+        @warn "Imaginary part of the second Chern number has a finite value."
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -661,6 +661,9 @@ const np = pyimport("numpy")
 
     @testset "4D case" begin
         @testset "SecondChern" begin
+            @test_logs (:warn, r"Imaginary part") TopologicalNumbers.warn_finiteImaginary(im)
+            @test_logs TopologicalNumbers.warn_finiteImaginary(0.0)
+
             @testset "Lattice Dirac model" begin
                 function H₀(k, p) # landau
                     k1, k2, k3, k4 = k


### PR DESCRIPTION
## 概要

有限の虚部を検出する警告処理を安定化し、警告有無をテストします。

## 検証

全変更を集約した統合監査で、Julia 1.12.6は293/293、Julia 1.6.7は全テスト、性能ゲートは6/6、Documenterビルドは成功しています。

## 依存・マージ順

codex/fix-second-chern-anisotropic-mesh の後にrebaseすることを推奨します。