### PR TITLE
Z₂計算の入力を検証する

### DIFF
--- a/src/calcZ2.jl
+++ b/src/calcZ2.jl
@@ -376,6 +376,38 @@ function Z2sol(TR, p::Params)
     end
 end
 
+"""
+    z2HamiltonianSize(Hamiltonian)
+
+Hamiltonian が正方行列を返すことを確認し、その次元を返す。
+"""
+function z2HamiltonianSize(Hamiltonian::Function)
+    H = Hamiltonian(zeros(2))
+    size(H, 1) == size(H, 2) ||
+        throw(ArgumentError("Hamiltonian should return a square matrix"))
+    return size(H, 1)
+end
+
+"""
+    validateZ2Parameters(N, Nfill, Hs)
+
+Z₂ 数の計算前に、メッシュ数・占有バンド数・Hamiltonian の次元を検証する。
+検証済みの占有バンド数を返し、`Nfill === nothing` の場合は半充填を用いる。
+"""
+function validateZ2Parameters(N::Int, Nfill::Union{Int,Nothing}, Hs::Int)
+    N > 0 || throw(ArgumentError("N should be positive"))
+    iseven(N) || throw(ArgumentError("N should be an even number"))
+    Hs >= 2 || throw(ArgumentError("Hamiltonian size should be at least 2"))
+    iseven(Hs) || throw(ArgumentError("Hamiltonian size should be an even number"))
+
+    validatedNfill = isnothing(Nfill) ? Hs ÷ 2 : Nfill
+    0 < validatedNfill < Hs ||
+        throw(ArgumentError("Nfill should be positive and smaller than the Hamiltonian size"))
+    iseven(validatedNfill) || throw(ArgumentError("Nfill should be an even number"))
+
+    return validatedNfill
+end
+
 @doc raw"""
 
  Calculate the $\mathbb{Z}_2$ numbers in the two-dimensional case with reference to Shiozaki method [Fukui2007Quantum,Shiozaki2023discrete](@cite).
@@ -383,9 +415,9 @@ end
     calcZ2(Hamiltonian::Function; Nfill::T1=nothing, N::Int=50, rounds::Bool=true, TR::Bool=false) where {T1<:Union{Int,Nothing}}
 
  Arguments
- - `Hamiltonian::Function` is a matrix with one-dimensional wavenumber `k` as an argument.
+ - `Hamiltonian::Function` is a matrix with two-dimensional wavenumber `k` as an argument.
  - `Nfill::T1`: The filling number. The default value is `Hs ÷ 2`, where `Hs` is the size of the Hamiltonian matrix.
- - `N::Int` is the number of meshes when discretizing the Brillouin Zone. It is preferable for `N` to be an odd number to increase the accuracy of the calculation.
+ - `N::Int` is a positive, even number of meshes used to discretize each direction of the Brillouin zone.
  - `rounds::Bool` is an option to round the value of the topological number to an integer value. The topological number returns a value of type `Int` when `true`, and a value of type `Float` when `false`.
 
 # Definition
@@ -414,19 +446,8 @@ U_{n,i}(\bm{k})=\braket{\Psi_{n}(\bm{k})|\Psi_{n}(\bm{k}+\bm{e}_{i})}
 function calcZ2(
     Hamiltonian::Function; Nfill::T1=nothing, N::Int=50, rounds::Bool=true, TR::Bool=false
 ) where {T1<:Union{Int,Nothing}}
-    Hs = size(Hamiltonian(zeros(2)), 1)
-    Hshalf = Hs ÷ 2
-    if isodd(N)
-        throw(ArgumentError("N should be an even number"))
-    else
-        if isnothing(Nfill)
-            Nfill = Hshalf
-        elseif isodd(Nfill)
-            throw(ArgumentError("Nfill should be an even number"))
-        elseif Nfill > Hs
-            throw(ArgumentError("Nfill should be smaller than the Hamiltonian size"))
-        end
-    end
+    Hs = z2HamiltonianSize(Hamiltonian)
+    Nfill = validateZ2Parameters(N, Nfill, Hs)
     p = Params(; Ham=Hamiltonian, Nfill, N, Hs, gapless=0.0, rounds, dim=2)
 
     r = Z2sol(TR, p)
@@ -469,17 +490,8 @@ function solve(
 ) where {T1<:Z2Algorithms,T2<:TopologicalNumbersParallel}
     @unpack H, Nfill, N, rounds, TR = prob
 
-    Hs = size(H(zeros(2)), 1)
-    Hshalf = Hs ÷ 2
-    if isodd(N)
-        throw(ArgumentError("N should be an even number"))
-    else
-        if isnothing(Nfill)
-            Nfill = Hshalf
-        elseif isodd(Nfill)
-            throw(ArgumentError("Nfill should be an even number"))
-        end
-    end
+    Hs = z2HamiltonianSize(H)
+    Nfill = validateZ2Parameters(N, Nfill, Hs)
 
     p = Params(; Ham=H, Nfill, N, Hs, rounds, dim=2)
 

--- a/src/phaseDiagram.jl
+++ b/src/phaseDiagram.jl
@@ -1143,7 +1143,7 @@ function calcPhaseDiagram(
 
     dim = 2
     Ham(k) = H(k, 0.0)
-    Hs = size(Ham(zeros(2)), 1)
+    Hs = z2HamiltonianSize(Ham)
 
     p = Params(; Ham, dim, N, gapless, rounds, Hs)
 
@@ -1249,7 +1249,7 @@ function calcPhaseDiagram(
 
     dim = 2
     Ham(k) = H(k, (0.0, 0.0))
-    Hs = size(Ham(zeros(2)), 1)
+    Hs = z2HamiltonianSize(Ham)
 
     p = Params(; Ham, dim, N, gapless, rounds, Hs)
 
@@ -1340,10 +1340,7 @@ function calcPhaseDiagram(
     dim = 2
     Ham(k) = H(k, 0.0)
     Hs = size(Ham(zeros(2)), 1)
-
-    if isnothing(Nfill)
-        Nfill = Hs ÷ 2
-    end
+    Nfill = validateZ2Parameters(N, Nfill, Hs)
 
     p = Params(; Ham, dim, Nfill, N, rounds, Hs)
 
@@ -1446,10 +1443,7 @@ function calcPhaseDiagram(
     dim = 2
     Ham(k) = H(k, (0.0, 0.0))
     Hs = size(Ham(zeros(2)), 1)
-
-    if isnothing(Nfill)
-        Nfill = Hs ÷ 2
-    end
+    Nfill = validateZ2Parameters(N, Nfill, Hs)
 
     p = Params(; Ham, dim, Nfill, N, rounds, Hs)
 

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -218,14 +218,14 @@ SCProblem(H, N, Nf) = SCProblem(; H=H, N=N, Nfill=Nf)
 
 # Problem for calculating the Z2 invariant
 @doc raw"""
-    Z2Problem{T1<:Function,T2<:Union{Int,Nothing},T3<:Union{Tuple,AbstractVector,Int},T4<:Bool} <: TopologicalNumbersProblems
+    Z2Problem{T1<:Function,T2<:Union{Int,Nothing},T3<:Int,T4<:Bool} <: TopologicalNumbersProblems
 
 A struct representing a problem for calculating the Z2 number.
 
 # Fields
 - `H::T1`: The Hamiltonian function `H=H(k, p)` that defines the system. `k` is a abstract vector (or a tuple) of the wavenumber vector and `p` contains parameter. Dimension of `k` must be 2.
 - `Nfill::T2`: The number of filled bands. `nothing` means the half-filling. Default is `nothing`.
-- `N::T3`: The number of points for one direction in the Brillouin zone. Default is 50.
+- `N::T3`: A positive, even number of points for one direction in the Brillouin zone. Default is 50.
 - `rounds::T4`: A boolean indicating whether to round a returned variable. Default is true.
 - `TR::T4`: A boolean indicating whether to calculate the remaining part of the Brillouin zone. If `true`, `solve` returns an additional result `TRTopologicalNumber`. If the calculation is done nomally, `TRTopologicalNumber` is equal to `TopologicalNumber`. Default is false.
 
@@ -235,7 +235,7 @@ julia>
 ```
 """
 Base.@kwdef struct Z2Problem{
-    T1<:Function,T2<:Union{Int,Nothing},T3<:Union{Tuple,AbstractVector,Int},T4<:Bool
+    T1<:Function,T2<:Union{Int,Nothing},T3<:Int,T4<:Bool
 } <: TopologicalNumbersProblems
     H::T1
     Nfill::T2 = nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -454,6 +454,28 @@ const np = pyimport("numpy")
             @test H₀((0.0, 0.0), (1, 1.0)) == KaneMele((0.0, 0.0), 1.0)
             H(k) = H₀(k, (1.0, 1.0))
 
+            @testset "入力検証" begin
+                @test_throws ArgumentError calcZ2(H; N=0)
+                @test_throws ArgumentError calcZ2(H; N=3)
+                @test_throws ArgumentError calcZ2(H; Nfill=0)
+                @test_throws ArgumentError calcZ2(H; Nfill=1)
+                @test_throws ArgumentError calcZ2(H; Nfill=4)
+                @test_throws MethodError Z2Problem(; H=H, N=(4, 4))
+
+                Hodd(k) = zeros(ComplexF64, 3, 3)
+                @test_throws ArgumentError calcZ2(Hodd)
+                Hrect(k) = zeros(ComplexF64, 4, 2)
+                @test_throws ArgumentError calcZ2(Hrect)
+                @test_throws ArgumentError solve(Z2Problem(; H=H, N=3))
+                H1(k, p) = H₀(k, (p, 1.0))
+                @test_throws ArgumentError calcPhaseDiagram(
+                    Z2Problem(; H=H1, N=3), [0.0]
+                )
+                @test_throws ArgumentError calcPhaseDiagram(
+                    Z2Problem(; H=H₀, N=3), [0.0], [0.0]
+                )
+            end
+
             N = 51
             k = range(-π, π; length=N)
             bandsum = (


### PR DESCRIPTION
## 概要

メッシュ、充填数、Hamiltonian次元の不正入力を明示的なArgumentErrorとして扱います。

## 検証

全変更を集約した統合監査で、Julia 1.12.6は293/293、Julia 1.6.7は全テスト、性能ゲートは6/6、Documenterビルドは成功しています。

## 依存・マージ順

Z₂関連修正の最初にマージすることを推奨します。