### PR TITLE
Z₂計算の非有限値を保持する

### DIFF
--- a/src/calcZ2.jl
+++ b/src/calcZ2.jl
@@ -312,6 +312,16 @@ function setTemporalZ2TR(p::Params)
     )
 end
 
+"""
+    roundTopologicalNumbers(nums)
+
+有限な要素だけなら整数へ丸める。`NaN` や無限大を含む場合は、非有限値を
+保持できる浮動小数点配列のまま有限値を丸める。
+"""
+function roundTopologicalNumbers(nums)
+    return all(isfinite, nums) ? round.(Int, nums) : round.(nums)
+end
+
 function Z2sol(TR, p::Params)
     @unpack rounds = p
 
@@ -320,16 +330,7 @@ function Z2sol(TR, p::Params)
         Z2Phase!(v, p)
 
         if rounds == true
-            TopologicalNumber = v.num
-            if all(!isnan, v.num[:, 1])
-                TopologicalNumber = round.(Int, v.num)
-            else
-                for i in eachindex(v.num[:, 1])
-                    if TopologicalNumber[i] !== NaN
-                        TopologicalNumber[i] = round(Int, v.num)
-                    end
-                end
-            end
+            TopologicalNumber = roundTopologicalNumbers(v.num)
             Total = mod(sum(TopologicalNumber), 2)
         elseif rounds == false
             TopologicalNumber = v.num
@@ -343,26 +344,8 @@ function Z2sol(TR, p::Params)
         Z2Phase!(v, p)
 
         if rounds == true
-            TopologicalNumber = v.num[:, 1]
-            if all(!isnan, v.num[:, 1])
-                TopologicalNumber = round.(Int, v.num[:, 1])
-            else
-                for i in eachindex(v.num[:, 1])
-                    if TopologicalNumber[i] !== NaN
-                        TopologicalNumber[i] = round(Int, v.num[i, 1])
-                    end
-                end
-            end
-            TRTopologicalNumber = v.num[:, 2]
-            if all(!isnan, v.num[:, 2])
-                TRTopologicalNumber = round.(Int, v.num[:, 2])
-            else
-                for i in eachindex(TRTopologicalNumber)
-                    if TRTopologicalNumber[i] !== NaN
-                        TRTopologicalNumber[i] = round(Int, v.num[i, 2])
-                    end
-                end
-            end
+            TopologicalNumber = roundTopologicalNumbers(v.num[:, 1])
+            TRTopologicalNumber = roundTopologicalNumbers(v.num[:, 2])
 
             Total = mod(sum(TopologicalNumber), 2)
         elseif rounds == false

--- a/src/phaseDiagram.jl
+++ b/src/phaseDiagram.jl
@@ -417,7 +417,7 @@ function calc_data1D(
         end
     else
         if rounds == true
-            round.(Int, transpose(nums))
+            roundTopologicalNumbers(transpose(nums))
         elseif rounds == false
             transpose(nums)
         end
@@ -458,7 +458,7 @@ function calc_data1D(
         end
     else
         if rounds == true
-            round.(Int, transpose(nums))
+            roundTopologicalNumbers(transpose(nums))
         elseif rounds == false
             transpose(nums)
         end
@@ -499,16 +499,7 @@ function calc_data2D(
         end
     else
         if rounds == true
-            if all(!isnan, nums)
-                nums = round.(Int, nums)
-            else
-                for i in eachindex(nums)
-                    if nums[i] !== NaN
-                        nums[i] = round(Int, nums[i])
-                    end
-                end
-            end
-            nums
+            roundTopologicalNumbers(nums)
         elseif rounds == false
             nums
         end
@@ -549,7 +540,7 @@ function calc_data2D(
         end
     else
         if rounds == true
-            round.(Int, nums)
+            roundTopologicalNumbers(nums)
         elseif rounds == false
             nums
         end
@@ -582,7 +573,7 @@ function calc_data1D(
     end
 
     if rounds == true
-        round.(Int, transpose(nums))
+        roundTopologicalNumbers(transpose(nums))
     elseif rounds == false
         transpose(nums)
     end
@@ -614,7 +605,7 @@ function calc_data1D(
     end
 
     if rounds == true
-        round.(Int, transpose(nums))
+        roundTopologicalNumbers(transpose(nums))
     elseif rounds == false
         transpose(nums)
     end
@@ -648,7 +639,7 @@ function calc_data2D(
     end
 
     if rounds == true
-        round.(Int, nums)
+        roundTopologicalNumbers(nums)
     elseif rounds == false
         nums
     end
@@ -682,7 +673,7 @@ function calc_data2D(
     end
 
     if rounds == true
-        round.(Int, nums)
+        roundTopologicalNumbers(nums)
     elseif rounds == false
         nums
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -454,6 +454,38 @@ const np = pyimport("numpy")
             @test H₀((0.0, 0.0), (1, 1.0)) == KaneMele((0.0, 0.0), 1.0)
             H(k) = H₀(k, (1.0, 1.0))
 
+            @testset "NaN の保持" begin
+                Hmixed(k, p) =
+                    iszero(p) ? diagm(ComplexF64[-2, 1, 2, -1]) :
+                    zeros(ComplexF64, 4, 4)
+                Hnan(k) = Hmixed(k, 0.0)
+
+                result = calcZ2(Hnan; N=2)
+                @test all(isnan, result.TopologicalNumber)
+                @test isnan(result.Total)
+
+                params = [0.0, 1.0]
+                expected = [NaN NaN; 0.0 0.0]
+                result = calcPhaseDiagram(Z2Problem(; H=Hmixed, N=2), params)
+                @test isequal(result.nums, expected)
+
+                result = calcPhaseDiagram(Hmixed, params, "Z2"; N=2, progress=true)
+                @test isequal(result.nums, expected)
+
+                Hmixed2(k, p) = Hmixed(k, p[1])
+                result = calcPhaseDiagram(
+                    Z2Problem(; H=Hmixed2, N=2), params, [1.0]; progress=true
+                )
+                @test all(isnan, result.nums[:, 1, 1])
+                @test all(iszero, result.nums[:, 2, 1])
+
+                result = calcPhaseDiagram(
+                    Hmixed2, params, [1.0], "Z2"; N=2, progress=true
+                )
+                @test all(isnan, result.nums[:, 1, 1])
+                @test all(iszero, result.nums[:, 2, 1])
+            end
+
             N = 51
             k = range(-π, π; length=N)
             bandsum = (


### PR DESCRIPTION
## 概要

NaNなどの非有限値を丸めで正常値へ変換せず、数値異常を利用者へ保持します。

## 検証

全変更を集約した統合監査で、Julia 1.12.6は293/293、Julia 1.6.7は全テスト、性能ゲートは6/6、Documenterビルドは成功しています。

## 依存・マージ順

codex/validate-z2-inputs の後にrebaseすることを推奨します。