### PR TITLE
plot2Dの2次元結果ディスパッチを修正する

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -296,18 +296,20 @@ function plot2D(
     svg::Bool=false,
     filename::String="phaseDiagram",
 )
+    nums_half = if result.nums isa AbstractMatrix
+        transpose(result.nums)
+    elseif ndims(result.nums) == 3
+        transpose(sum(@view(result.nums[1:(end ÷ 2), :, :]); dims=1)[1, :, :])
+    else
+        throw(ArgumentError("result.nums should be a two- or three-dimensional array"))
+    end
+
     fig = figure()
     ax = fig.add_subplot(111)
 
     if labels == true
         ax.set_xlabel(L"p_1")
         ax.set_ylabel(L"p_2")
-    end
-
-    nums_half = if result.nums isa Array{Float64,2}
-        transpose(result.nums)
-    else
-        transpose(sum(@view(result.nums[1:(end ÷ 2), :, :]); dims=1)[1, :, :])
     end
 
     if disp == true || png == true || pdf == true || svg == true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -133,6 +133,23 @@ const np = pyimport("numpy")
         @test typeof(fig) == Figure
         plotclose()
 
+        @testset "2次元行列の結果" begin
+            matrix = Int[0 1 0; 1 0 1; 0 1 0]
+            matrix_result = (; param1=param, param2=param, nums=matrix)
+            fig = plot2D(matrix_result; disp=false)
+            @test typeof(fig) == Figure
+            plotclose()
+
+            view_result = (; param1=param, param2=param, nums=@view(matrix[:, :]))
+            fig = plot2D(view_result; disp=false)
+            @test typeof(fig) == Figure
+            plotclose()
+
+            invalid_result = (; param1=param, param2=param, nums=zeros(3))
+            @test_throws ArgumentError plot2D(invalid_result; disp=false)
+            plotclose()
+        end
+
         param = range(-2.0, 2.0; length=4)
         result = calcPhaseDiagram(H₀, param, param, "BerryPhase"; rounds=false)
         num = zeros(2, 4, 4)


### PR DESCRIPTION
## 概要

行列形式のphase diagram結果をNamedTupleから正しく描画し、不正次元を明示的に拒否します。

## 検証

全変更を集約した統合監査で、Julia 1.12.6は293/293、Julia 1.6.7は全テスト、性能ゲートは6/6、Documenterビルドは成功しています。

## 依存・マージ順

独立した描画修正です。