### PR TITLE
Documenter依存の互換範囲を固定する

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,3 +2,9 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterCitations = "daee34ce-89f3-4625-b898-19384cb65244"
 TopologicalNumbers = "82b459e2-751c-486c-8b84-4a85e9d7ad51"
+
+[compat]
+Documenter = "1.17"
+DocumenterCitations = "1.4"
+TopologicalNumbers = "1.7"
+julia = "1.10"


### PR DESCRIPTION
## 概要

docs環境へJulia、Documenter、DocumenterCitationsのcompatを追加します。

## 検証

全変更を集約した統合監査で、Julia 1.12.6は293/293、Julia 1.6.7は全テスト、性能ゲートは6/6、Documenterビルドは成功しています。

## 依存・マージ順

Documenter関連PRの最初にマージすることを推奨します。