### PR TITLE
Documenterのメタデータ警告を解消する

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,6 +18,7 @@ makedocs(;
         prettyurls=get(ENV, "CI", "false") == "true",
         canonical="https://KskAdch.github.io/TopologicalNumbers.jl",
         edit_link="main",
+        repolink="https://github.com/KskAdch/TopologicalNumbers.jl",
         assets=String[],
     ),
     pages=[

--- a/docs/src/docs.bib
+++ b/docs/src/docs.bib
@@ -21,6 +21,7 @@
   primaryclass = {cond-mat},
   publisher = {{arXiv}},
   doi = {10.48550/arXiv.2305.05615},
+  url = {https://doi.org/10.48550/arXiv.2305.05615},
   urldate = {2023-07-29},
   archiveprefix = {arxiv}
 }
@@ -35,6 +36,7 @@
   pages = {235152},
   publisher = {{American Physical Society}},
   doi = {10.1103/PhysRevB.96.235152},
+  url = {https://doi.org/10.1103/PhysRevB.96.235152},
   urldate = {2024-01-23}
 }
 
@@ -48,6 +50,7 @@
   pages = {206401},
   publisher = {{American Physical Society}},
   doi = {10.1103/PhysRevLett.114.206401},
+  url = {https://doi.org/10.1103/PhysRevLett.114.206401},
   urldate = {2024-01-23}
 }
 
@@ -62,6 +65,7 @@
   publisher = {{The Physical Society of Japan}},
   issn = {0031-9015},
   doi = {10.7566/JPSJ.87.041002},
+  url = {https://doi.org/10.7566/JPSJ.87.041002},
   urldate = {2024-01-23}
 }
 
@@ -76,6 +80,7 @@
   pages = {075129},
   publisher = {{American Physical Society}},
   doi = {10.1103/PhysRevB.84.075129},
+  url = {https://doi.org/10.1103/PhysRevB.84.075129},
   urldate = {2024-01-23}
 }
 @article{Fukui2007Quantum,


### PR DESCRIPTION
## 概要

文献情報とDocumenter設定を修正し、文書ビルド時の内容警告を除去します。

## 検証

全変更を集約した統合監査で、Julia 1.12.6は293/293、Julia 1.6.7は全テスト、性能ゲートは6/6、Documenterビルドは成功しています。

## 依存・マージ順

codex/pin-docs-dependencies の後を推奨します。