### PR TITLE
公開API文書を分割する

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -39,7 +39,17 @@ makedocs(;
             "Four-dimensional case (Z)" =>
                 ["Lattice Dirac model" => "4D/LatticeDirac.md"],
         ],
-        "Library" => ["Public" => "lib/public.md", "Internal" => "lib/internal.md"],
+        "Library" => [
+            "Public API" => [
+                "Overview" => "lib/public.md",
+                "Problems and algorithms" => "lib/problems.md",
+                "Topological invariants" => "lib/invariants.md",
+                "Weyl points and Berry flux" => "lib/weyl.md",
+                "Models and visualization" => "lib/models.md",
+                "Pfaffian utilities" => "lib/pfaffian.md",
+            ],
+            "Internal" => "lib/internal.md",
+        ],
         "References" => "references.md",
     ],
 )

--- a/docs/src/lib/invariants.md
+++ b/docs/src/lib/invariants.md
@@ -1,0 +1,15 @@
+# Topological invariants
+
+Berry 位相、第一・第二 Chern 数、``\mathbb{Z}_2`` 不変量、相図の公開 API です。
+
+```@autodocs
+Modules = [TopologicalNumbers]
+Pages = [
+    "calcBerryPhase.jl",
+    "calcChern.jl",
+    "calcZ2.jl",
+    "SecondChern.jl",
+    "phaseDiagram.jl",
+]
+Private = false
+```

--- a/docs/src/lib/models.md
+++ b/docs/src/lib/models.md
@@ -1,0 +1,9 @@
+# Models and visualization
+
+組み込み模型、バンド分散、一次元・二次元相図の描画 API です。
+
+```@autodocs
+Modules = [TopologicalNumbers]
+Pages = ["models.jl", "showBand.jl", "plot.jl"]
+Private = false
+```

--- a/docs/src/lib/pfaffian.md
+++ b/docs/src/lib/pfaffian.md
@@ -1,0 +1,9 @@
+# Pfaffian utilities
+
+Pfaffian と歪対称行列の三重対角化に関する公開 API です。
+
+```@autodocs
+Modules = [TopologicalNumbers]
+Pages = ["pfaffian.jl"]
+Private = false
+```

--- a/docs/src/lib/problems.md
+++ b/docs/src/lib/problems.md
@@ -1,0 +1,9 @@
+# Problems and algorithms
+
+問題、解法、解オブジェクト、並列化方式の公開 API です。
+
+```@autodocs
+Modules = [TopologicalNumbers]
+Pages = ["algorithms.jl", "problems.jl", "parallelEnv.jl"]
+Private = false
+```

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -1,6 +1,9 @@
-# Public
+# Public API
 
-```@autodocs
-Modules = [TopologicalNumbers]
-Private = false
-```
+公開 API を目的別に掲載しています。
+
+- 問題・解法・並列化方式を選ぶ場合は「Problems and algorithms」
+- 各トポロジカル不変量を直接計算する場合は「Topological invariants」
+- Weyl 点や局所 Berry flux を扱う場合は「Weyl points and Berry flux」
+- 模型 Hamiltonian、バンド、相図を扱う場合は「Models and visualization」
+- Pfaffian と歪対称行列の数値計算には「Pfaffian utilities」

--- a/docs/src/lib/weyl.md
+++ b/docs/src/lib/weyl.md
@@ -1,0 +1,14 @@
+# Weyl points and Berry flux
+
+局所 Berry flux、Weyl 点の電荷、探索、断面 Chern 数の公開 API です。
+
+```@autodocs
+Modules = [TopologicalNumbers]
+Pages = [
+    "calcBerryFlux.jl",
+    "calcWeylNode.jl",
+    "calcChernSurface.jl",
+    "findWeylPoint.jl",
+]
+Private = false
+```


### PR DESCRIPTION
## 概要

巨大な公開APIページを不変量、模型、Problem、Weyl、Pfaffianへ分割し、Documenter出力を軽量化します。

## 検証

全変更を集約した統合監査で、Julia 1.12.6は293/293、Julia 1.6.7は全テスト、性能ゲートは6/6、Documenterビルドは成功しています。

## 依存・マージ順

codex/pin-docs-dependencies、codex/clean-documenter-warnings、codex/improve-api-docstrings の後を推奨します。