### PR TITLE
2点走査でもSecond Chern相図を描画可能にする

### DIFF
--- a/src/phaseDiagram.jl
+++ b/src/phaseDiagram.jl
@@ -816,7 +816,7 @@ function calcPhaseDiagram(
 
     if alg == FHS2()
         if plot == true
-            plot2D(transpose(nums_half), param_range1, param_range2)
+            plot2D(transpose(nums), param_range1, param_range2)
         end
     else
         if plot == true && Hs % 2 == 0
@@ -860,7 +860,7 @@ function calcPhaseDiagram2D_core(
 
     if alg isa FHS2
         if plot == true
-            plot2D(transpose(nums_half), param_range1, param_range2)
+            plot2D(transpose(nums), param_range1, param_range2)
         end
     else
         if plot == true && p.Hs % 2 == 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -715,6 +715,25 @@ const np = pyimport("numpy")
                     digits=20,
                 )
 
+                function Hflat(k, p)
+                    k1, k2, k3, k4 = k
+                    return Matrix(Diagonal(ComplexF64[-2, -1, 1, 2]))
+                end
+                flat_prob = SCProblem(Hflat, (1, 1, 1, 1))
+                expected = calcPhaseDiagram(flat_prob, [0.0], [0.0])
+                actual = @test_nowarn calcPhaseDiagram(
+                    flat_prob, [0.0], [0.0]; plot=true
+                )
+                @test actual == expected
+                plotclose()
+
+                expected = calcPhaseDiagram(Hflat, [0.0], [0.0], FHS2(); N=1)
+                actual = @test_nowarn calcPhaseDiagram(
+                    Hflat, [0.0], [0.0], FHS2(); N=1, plot=true
+                )
+                @test actual == expected
+                plotclose()
+
                 param = range(-4.9, 4.9; length=4)
                 result = calcPhaseDiagram(H₀, param, FHS2(); N=10)
                 calcPhaseDiagram(H₀, param, FHS2(); N=10, progress=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -720,16 +720,17 @@ const np = pyimport("numpy")
                     return Matrix(Diagonal(ComplexF64[-2, -1, 1, 2]))
                 end
                 flat_prob = SCProblem(Hflat, (1, 1, 1, 1))
-                expected = calcPhaseDiagram(flat_prob, [0.0], [0.0])
+                plot_params = [0.0, 1.0]
+                expected = calcPhaseDiagram(flat_prob, plot_params, plot_params)
                 actual = @test_nowarn calcPhaseDiagram(
-                    flat_prob, [0.0], [0.0]; plot=true
+                    flat_prob, plot_params, plot_params; plot=true
                 )
                 @test actual == expected
                 plotclose()
 
-                expected = calcPhaseDiagram(Hflat, [0.0], [0.0], FHS2(); N=1)
+                expected = calcPhaseDiagram(Hflat, plot_params, plot_params, FHS2(); N=1)
                 actual = @test_nowarn calcPhaseDiagram(
-                    Hflat, [0.0], [0.0], FHS2(); N=1, plot=true
+                    Hflat, plot_params, plot_params, FHS2(); N=1, plot=true
                 )
                 @test actual == expected
                 plotclose()


### PR DESCRIPTION
## 概要

Second Chern相図の走査点が2点だけの場合にも、特異な描画範囲を作らず結果を可視化できるようにします。

## 検証

- 統合検証: Julia 1.12.6でPkg.test 293/293、Julia 1.6.7でPkg.test成功、性能テスト6/6、Documenterビルド、JuliaFormatter 1.0.62を確認済み。

## 推奨マージ順

- 追加セット内 1/11