### PR TITLE
Berry phaseメッシュ入力を検証する

### DIFF
--- a/src/calcBerryPhase.jl
+++ b/src/calcBerryPhase.jl
@@ -73,10 +73,22 @@ end
     return phi .= angle.(v.Link)
 end
 
+"""
+    validateBerryPhaseMesh(N)
+
+Berry 位相を計算できるように、メッシュ数 `N` が正の整数であることを確認する。
+"""
+function validateBerryPhaseMesh(N)
+    N isa Int && N > 0 || throw(ArgumentError("`N` には正の整数を指定してください"))
+    return nothing
+end
+
 @doc raw"""
 """
 @views function BerryPhase!(TopologicalNumber, p::Params) # berry phase
     @unpack N, Hs = p
+    validateBerryPhaseMesh(N)
+
     Link = zeros(ComplexF64, Hs)
 
     Evec0 = zeros(Hs)
@@ -112,7 +124,7 @@ end
 
  Arguments
  - `Hamiltonian::Function`: the Hamiltonian matrix function with one-dimensional wavenumber `k` as an argument.
- - `N::Int`: the number of meshes when discretizing the Brillouin Zone. It is preferable for `N` to be an odd number to increase the accuracy of the calculation.
+ - `N::Int`: Brillouin zone を離散化するメッシュ数。正の整数を指定してください。計算精度を高めるには奇数が推奨されます。
  - `gapless::Real`: the threshold that determines the state to be degenerate. Coarsening the mesh(`N`) but increasing `gapless` will increase the accuracy of the calculation.
  - `rounds::Bool`: an option to round the value of the topological number to an integer value. The topological number returns a value of type `Int` when `true`, and a value of type `Float` when `false`.
 

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -8,7 +8,7 @@ The `BPProblem` struct represents a problem for calculating Berry phase.
 
 # Fields
 - `H::T1`: The Hamiltonian function `H=H(k, p)` that defines the system. `k` is a abstract vector (or a tuple) of the wavenumber vector and `p` contains parameter. Dimension of `k` must be 1.
-- `N::T2`: The number of points for one direction in the Brillouin zone. Default is 51.
+- `N::T2`: Brillouin zone の1方向あたりのメッシュ数。正の整数を指定してください。既定値は51です。
 - `gapless::T3`: The threshold for considering a band as gapless. Default is 0.0.
 - `rounds::T4`: A boolean indicating whether to round a returned variable. Default is true.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,8 @@ const np = pyimport("numpy")
         @test abs(sum(result.Ene)) < 1e-10
 
         @test calcBerryPhase(H) == (TopologicalNumber=[1, 1], Total=0)
+        @test_throws ArgumentError calcBerryPhase(H; N=0)
+        @test_throws ArgumentError calcBerryPhase(H; N=-1)
 
         @test norm(
             calcBerryPhase(H).TopologicalNumber -
@@ -66,6 +68,13 @@ const np = pyimport("numpy")
         BPProblem(H, 41)
         prob = BPProblem(H)
         @test solve(prob).TopologicalNumber == [1, 1]
+
+        @test_throws ArgumentError solve(BPProblem(H, 0))
+
+        Hparam(k, p) = H(k)
+        invalid_prob = BPProblem(Hparam, 0)
+        @test_throws ArgumentError calcPhaseDiagram(invalid_prob, [0.0])
+        @test_throws ArgumentError calcPhaseDiagram(Hparam, [0.0], BP(); N=(1,))
 
         H(k, p) = H₀(k, (p, 1.0))
 


### PR DESCRIPTION
## 概要

Berry phase計算のメッシュ値を早期検証し、不正入力を明確なArgumentErrorとして報告します。

## 検証

- 統合検証: Julia 1.12.6でPkg.test 293/293、Julia 1.6.7でPkg.test成功、性能テスト6/6、Documenterビルド、JuliaFormatter 1.0.62を確認済み。

## 推奨マージ順

- 追加セット内 2/11（fix-second-chern-phase-plotの後）