### PR TITLE
Weyl点探索アルゴリズムの入力を検証する

### DIFF
--- a/src/calcChernSurface.jl
+++ b/src/calcChernSurface.jl
@@ -75,12 +75,12 @@ end
 @doc raw"""
 Calculate the sliced first Chern numbers in the three-dimensional case with reference to Fukui-Hatsugai-Suzuki method [Fukui2005Chern](@cite).
 
-    solve(prob::WCSProblem, alg::T1=FHSsurface(); parallel::T2=UseSingleThread()) where {T1<:WeylPointsAlgorithms,T2<:TopologicalNumbersParallel}
+    solve(prob::WCSProblem, alg::FHSsurface=FHSsurface(); parallel::T=UseSingleThread()) where {T<:TopologicalNumbersParallel}
 
 # Arguments
 - `prob::WCSProblem`: The WCSProblem struct that contains the Hamiltonian matrix function in the wave number space and other parameters.
-- `alg::T1=FHSsurface()`: The algorithm to use for calculating the sliced first Chern numbers. Default is `FHSsurface` algorithm.
-- `parallel::T2=UseSingleThread()`: The parallelization strategy to use. Default is to use a single thread.
+- `alg::FHSsurface=FHSsurface()`: sliced first Chern number の計算には `FHSsurface` を使用します。
+- `parallel::T=UseSingleThread()`: The parallelization strategy to use. Default is to use a single thread.
 
 # Returns
 - `WCSSolution`: A struct that contains the calculated sliced first Chern numbers.
@@ -166,8 +166,11 @@ julia> sol.nums
 
 """
 function solve(
-    prob::WCSProblem, alg::T1=FHSsurface(); parallel::T2=UseSingleThread(), plot::Bool=false
-) where {T1<:WeylPointsAlgorithms,T2<:TopologicalNumbersParallel}
+    prob::WCSProblem,
+    _alg::FHSsurface=FHSsurface();
+    parallel::T=UseSingleThread(),
+    plot::Bool=false,
+) where {T<:TopologicalNumbersParallel}
     @unpack H, kn, kn_mesh, N, gapless, rounds = prob
 
     Hs = size(H(zeros(3)), 1)
@@ -188,4 +191,13 @@ function solve(
     end
 
     return WCSSolution(; kn, param=kn_range, nums)
+end
+
+function solve(
+    prob::WCSProblem,
+    alg::WeylPointsAlgorithms;
+    parallel::TopologicalNumbersParallel=UseSingleThread(),
+    plot::Bool=false,
+)
+    throw(ArgumentError("WCSProblem では FHSsurface() を指定してください: $alg"))
 end

--- a/src/calcWeylNode.jl
+++ b/src/calcWeylNode.jl
@@ -194,12 +194,12 @@ end
 @doc raw"""
 Calculate the Weyl node in the three-dimensional case with reference to Fukui-Hatsugai-Suzuki method [Fukui2005Chern](@cite).
 
-    solve(prob::WNProblem, alg::T1=FHSlocal3(); parallel::T2=UseSingleThread()) where {T1<:WeylPointsAlgorithms,T2<:TopologicalNumbersParallel}
+    solve(prob::WNProblem, alg::FHSlocal3=FHSlocal3(); parallel::T=UseSingleThread()) where {T<:TopologicalNumbersParallel}
 
 # Arguments
 - `prob::WNProblem`: The WNProblem struct that contains the Hamiltonian matrix function in the wave number space and other parameters.
-- `alg::T1=FHSlocal3()`: The algorithm to use for calculating the Weyl nodes. Default is `FHSlocal3` algorithm.
-- `parallel::T2=UseSingleThread()`: The parallelization strategy to use. Default is to use a single thread.
+- `alg::FHSlocal3=FHSlocal3()`: Weyl node の計算には `FHSlocal3` を使用します。
+- `parallel::T=UseSingleThread()`: The parallelization strategy to use. Default is to use a single thread.
 
 # Returns
 - `WNSolution`: A struct that contains the calculated Weyl nodes.
@@ -238,8 +238,8 @@ julia> sol.TopologicalNumber
 
 """
 function solve(
-    prob::WNProblem, alg::T1=FHSlocal3(); parallel::T2=UseSingleThread()
-) where {T1<:WeylPointsAlgorithms,T2<:TopologicalNumbersParallel}
+    prob::WNProblem, _alg::FHSlocal3=FHSlocal3(); parallel::T=UseSingleThread()
+) where {T<:TopologicalNumbersParallel}
     @unpack H, n, N, gapless, rounds = prob
 
     Hs = size(H(n), 1)
@@ -262,4 +262,12 @@ function solve(
     end
 
     return WNSolution(; TopologicalNumber, n, N)
+end
+
+function solve(
+    prob::WNProblem,
+    alg::WeylPointsAlgorithms;
+    parallel::TopologicalNumbersParallel=UseSingleThread(),
+)
+    throw(ArgumentError("WNProblem では FHSlocal3() を指定してください: $alg"))
 end

--- a/src/findWeylPoint.jl
+++ b/src/findWeylPoint.jl
@@ -134,12 +134,12 @@ end
 @doc raw"""
 Calculate the Weyl points in the three-dimensional case using energy variational method.
 
-    solve(prob::WPProblem, alg::T1=Evar(); parallel::T2=UseSingleThread()) where {T1<:WeylPointsAlgorithms,T2<:TopologicalNumbersParallel}
+    solve(prob::WPProblem, alg::Evar=Evar(); parallel::T=UseSingleThread()) where {T<:TopologicalNumbersParallel}
 
 # Arguments
 - `prob::WPProblem`: The WPProblem struct that contains the Hamiltonian matrix function in the wave number space and other parameters.
-- `alg::T1=Evar()`: The algorithm to use for calculating the Weyl points. Default is `Evar` algorithm.
-- `parallel::T2=UseSingleThread()`: The parallelization strategy to use. Default is to use a single thread.
+- `alg::Evar=Evar()`: Weyl point の探索には `Evar` を使用します。
+- `parallel::T=UseSingleThread()`: The parallelization strategy to use. Default is to use a single thread.
 
 # Returns
 - `WPSolution`: A struct that contains the calculated Weyl points.
@@ -176,8 +176,8 @@ julia> 2pi*result.WeylPoint[1] / result.N .- pi*[ones(3), ones(3)]
 
 """
 function solve(
-    prob::WPProblem, alg::T1=Evar(); parallel::T2=UseSingleThread()
-) where {T1<:WeylPointsAlgorithms,T2<:TopologicalNumbersParallel}
+    prob::WPProblem, _alg::Evar=Evar(); parallel::T=UseSingleThread()
+) where {T<:TopologicalNumbersParallel}
     @unpack H, N, gapless, rounds = prob
 
     Hs = size(H(zeros(3)), 1)
@@ -202,4 +202,12 @@ function solve(
     weylpoint!(H, k0list, Nodes, Ni, Hs, rounds)
 
     return WPSolution(; WeylPoint=k0list, N=Ni, Nodes)
+end
+
+function solve(
+    prob::WPProblem,
+    alg::WeylPointsAlgorithms;
+    parallel::TopologicalNumbersParallel=UseSingleThread(),
+)
+    throw(ArgumentError("WPProblem では Evar() を指定してください: $alg"))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -596,6 +596,7 @@ const np = pyimport("numpy")
         @test result.TopologicalNumber == [1, -1]
         @test result.n == [4, 10, 10]
         @test result.N == 11
+        @test_throws ArgumentError solve(prob, Evar())
 
         N = 11
         nodes = zeros(N, N, N, 2)
@@ -630,6 +631,7 @@ const np = pyimport("numpy")
         @test result.kn == "k1"
         @test result.nums[:, 1] == [0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0]
         @test result.nums[:, 2] == -result.nums[:, 1]
+        @test_throws ArgumentError solve(prob, FHSlocal3())
 
         prob = WCSProblem(H₀, "k2", 11)
         result = solve(prob)
@@ -657,6 +659,7 @@ const np = pyimport("numpy")
             [[4000, 9990, 9990], [6000, 9990, 9990]],
         ]
         @test result.Nodes == [[1, -1], [-1, 1]]
+        @test_throws ArgumentError solve(prob, FHSsurface())
     end
 
     @testset "4D case" begin


### PR DESCRIPTION
## 概要

Weyl点探索・Chern面計算のアルゴリズム指定を検証し、未対応値を暗黙処理しないようにします。

## 検証

- 統合検証: Julia 1.12.6でPkg.test 293/293、Julia 1.6.7でPkg.test成功、性能テスト6/6、Documenterビルド、JuliaFormatter 1.0.62を確認済み。

## 推奨マージ順

- 追加セット内 3/11