### PR TITLE
多バンド描画のマーカーを循環利用する

### DIFF
--- a/src/plot.jl
+++ b/src/plot.jl
@@ -24,10 +24,7 @@ function marker(i)
         "_",
         "p",
     )
-    if i > length(markers)
-        i = i % length(markers)
-    end
-    return markers[i]
+    return markers[mod1(i, length(markers))]
 end
 
 @doc raw"""

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,6 +90,9 @@ const np = pyimport("numpy")
         @test typeof(fig) == Figure
         plotclose()
 
+        @test TopologicalNumbers.marker(1) == TopologicalNumbers.marker(24)
+        @test TopologicalNumbers.marker(23) == TopologicalNumbers.marker(46)
+
         result = calcPhaseDiagram(H, param, "BerryPhase"; rounds=false)
         num = [
             2.8271597168564594e-16 1.987846675914698e-17


### PR DESCRIPTION
## 概要

バンド数がマーカー候補数を超えてもインデックス範囲外にならないよう、マーカーを循環利用します。

## 検証

- 統合検証: Julia 1.12.6でPkg.test 293/293、Julia 1.6.7でPkg.test成功、性能テスト6/6、Documenterビルド、JuliaFormatter 1.0.62を確認済み。

## 推奨マージ順

- 追加セット内 5/11